### PR TITLE
Fix value proxying in OpenTelemetryWorkflowOutboundRequestInterceptor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,10 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "php-http/discovery": false
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": ">=8.1",
         "open-telemetry/sdk": "^0.0.17",
-        "temporal/sdk": "^2.6"
+        "temporal/sdk": "^2.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.2",

--- a/src/Interceptor/OpenTelemetryActivityInboundInterceptor.php
+++ b/src/Interceptor/OpenTelemetryActivityInboundInterceptor.php
@@ -19,18 +19,13 @@ final class OpenTelemetryActivityInboundInterceptor implements ActivityInboundIn
     use ActivityInboundInterceptorTrait, TracerContext;
 
     public function __construct(
-        private readonly Tracer $tracer
+        private readonly Tracer $tracer,
     ) {
     }
 
-    /**
-     * @throws \Throwable
-     */
     public function handleActivityInbound(ActivityInput $input, callable $next): mixed
     {
-        $tracer = $this->getTracerWithContext($input->header);
-
-        return $tracer->trace(
+        return $this->getTracerWithContext($input->header)->trace(
             name: SpanName::ActivityHandle->value,
             callback: static fn(): mixed => $next($input),
             attributes: [

--- a/src/Interceptor/OpenTelemetryWorkflowOutboundRequestInterceptor.php
+++ b/src/Interceptor/OpenTelemetryWorkflowOutboundRequestInterceptor.php
@@ -42,10 +42,15 @@ final class OpenTelemetryWorkflowOutboundRequestInterceptor implements WorkflowO
 
         return $result->then(
             fn(mixed $value): mixed => $this->trace($tracer, $request, static fn(): mixed => $value),
-            fn(\Throwable $error): mixed => $this->trace($tracer, $request, static fn(): mixed => throw $error),
+            fn(\Throwable $error): mixed => $this->trace($tracer, $request, static function () use ($error): never {
+                throw $error;
+            }),
         );
     }
 
+    /**
+     * @throws \Throwable
+     */
     private function trace(Tracer $tracer, RequestInterface $request, \Closure $handler): mixed
     {
         $now = ClockFactory::getDefault()->now();

--- a/tests/src/Unit/Interceptor/OpenTelemetryWorkflowOutboundRequestInterceptorTest.php
+++ b/tests/src/Unit/Interceptor/OpenTelemetryWorkflowOutboundRequestInterceptorTest.php
@@ -7,7 +7,9 @@ namespace Temporal\OpenTelemetry\Tests\Unit\Interceptor;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\SDK\Common\Time\ClockFactory;
 use OpenTelemetry\SDK\Common\Time\ClockInterface;
+use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
+use stdClass;
 use Temporal\DataConverter\ValuesInterface;
 use Temporal\Interceptor\HeaderInterface;
 use Temporal\OpenTelemetry\Enum\RequestAttribute;
@@ -53,7 +55,9 @@ final class OpenTelemetryWorkflowOutboundRequestInterceptorTest extends TestCase
             name: SpanName::WorkflowOutboundRequest->value . SpanName::SpanDelimiter->value . 'someRequest'
         );
 
-        $promise = new Promise();
+        $deferred = new Deferred();
+        $promise = $deferred->promise();
+        $testContext = (object)['value' => null, 'error' => null];
 
         $header = $this->createMock(HeaderInterface::class);
         $header
@@ -68,9 +72,70 @@ final class OpenTelemetryWorkflowOutboundRequestInterceptorTest extends TestCase
                 $this->createMock(ValuesInterface::class)
             ),
             fn ($receivedRequest): PromiseInterface => $promise
+        )->then(
+            fn ($value) => $testContext->value = $value,
+            fn ($error) => $testContext->error = $error,
         );
 
-        $callback = $promise->callback;
-        $callback();
+        $deferred->resolve('test-value');
+
+        // test that the promise is resolved with the correct value
+        $this->assertSame($testContext->value, 'test-value');
+        $this->assertNull($testContext->error);
+    }
+
+    public function testHandleOutboundRequestWithError(): void
+    {
+        $clock = $this->createMock(ClockInterface::class);
+        $clock
+            ->expects($this->once())
+            ->method('now')
+            ->willReturn(12345);
+
+        ClockFactory::setDefault($clock);
+
+        $info = new WorkflowInfo();
+        $info->type->name = 'foo';
+
+        $ctx = $this->createMock(WorkflowContextInterface::class);
+        $ctx->expects($this->once())->method('getInfo')->willReturn($info);
+        Workflow::setCurrentContext($ctx);
+        $exception = new \Exception('test-error');
+
+        $tracer = $this->configureTracerToRegisterException(
+            scoped: true,
+            spanKind: SpanKind::KIND_SERVER,
+            startTime: 12345,
+            name: SpanName::WorkflowOutboundRequest->value . SpanName::SpanDelimiter->value . 'someRequest',
+            exception: $exception,
+        );
+
+        $deferred = new Deferred();
+        $promise = $deferred->promise();
+        $testContext = (object)['value' => null, 'error' => null];
+
+        $header = $this->createMock(HeaderInterface::class);
+        $header
+            ->method('getValue')
+            ->with('_tracer-data')
+            ->willReturn(['some' => 'data']);
+
+        $interceptor = new OpenTelemetryWorkflowOutboundRequestInterceptor($tracer);
+        $interceptor->handleOutboundRequest(
+            new Request(
+                $header,
+                $this->createMock(ValuesInterface::class)
+            ),
+            fn ($receivedRequest): PromiseInterface => $promise
+        )->then(
+            fn (mixed $value) => $testContext->value = $value,
+            fn (\Throwable $error) => $testContext->error = $error,
+        );
+
+        $deferred->reject($exception);
+
+        // test that the promise is rejected with the correct error
+        $this->assertSame($exception, $testContext->error);
+        $this->assertNull($testContext->value);
     }
 }

--- a/tests/src/Unit/TestCase.php
+++ b/tests/src/Unit/TestCase.php
@@ -28,7 +28,7 @@ abstract class TestCase extends PHPUnitTestCase
         bool $scoped = false,
         ?int $spanKind = null,
         ?int $startTime = null,
-        string $name = 'foo'
+        string $name = 'foo',
     ): Tracer {
         if ($scoped) {
             $scope = $this->createMock(ScopeInterface::class);
@@ -46,6 +46,51 @@ abstract class TestCase extends PHPUnitTestCase
         $this->span->expects($this->once())->method('updateName')->with($name);
         $this->span->expects($this->once())->method('setAttributes')->with($attributes);
         $this->span->expects($this->once())->method('end');
+
+        $spanKind !== null
+            ? $this->spanBuilder->expects($this->once())->method('setSpanKind')->with($spanKind)
+            : $this->spanBuilder->expects($this->never())->method('setSpanKind');
+
+        $startTime !== null
+            ? $this->spanBuilder->expects($this->once())->method('setStartTimestamp')->with($startTime)
+            : $this->spanBuilder->expects($this->never())->method('setStartTimestamp');
+        $this->spanBuilder->expects($this->never())->method('setParent');
+        $this->spanBuilder->expects($this->once())->method('startSpan')->willReturn($this->span);
+
+        $otelTracer = $this->createMock(TracerInterface::class);
+        $otelTracer
+            ->expects($this->once())
+            ->method('spanBuilder')
+            ->with($name)
+            ->willReturn($this->spanBuilder);
+
+        return new Tracer($otelTracer, new TraceContextPropagator());
+    }
+
+    protected function configureTracerToRegisterException(
+        bool $scoped = false,
+        ?int $spanKind = null,
+        ?int $startTime = null,
+        string $name = 'foo',
+        ?\Throwable $exception = null,
+    ): Tracer {
+        if ($scoped) {
+            $scope = $this->createMock(ScopeInterface::class);
+            $scope
+                ->expects($this->once())
+                ->method('detach');
+
+            $this->span
+                ->expects($this->once())
+                ->method('activate')
+                ->willReturn($scope);
+        } else {
+            $this->span->expects($this->never())->method('activate');
+        }
+        $this->span->expects($this->once())->method('end');
+        $exception === null
+            ? $this->span->expects($this->once())->method('recordException')
+            : $this->span->expects($this->once())->method('recordException')->with($exception);
 
         $spanKind !== null
             ? $this->spanBuilder->expects($this->once())->method('setSpanKind')->with($spanKind)


### PR DESCRIPTION
## What was changed

Fixed OpenTelemetryWorkflowOutboundRequestInterceptor: value obtained as a result of executing the request was suppressed in the interceptor, instead of being passed further into the promise.
