### PR TITLE
Upgraded OpenTelemetry SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "open-telemetry/sdk": "^0.0.17",
+        "open-telemetry/sdk": "^1",
         "temporal/sdk": "^2.7"
     },
     "require-dev": {

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -35,6 +35,7 @@ final class Tracer
     /**
      * @param non-empty-string $name
      * @psalm-param SpanKind::KIND_* $spanKind
+     * @param array<non-empty-string, array<array-key, mixed>|null|scalar> $attributes
      * @throws \Throwable
      */
     public function trace(


### PR DESCRIPTION

<!--- For ALL Contributors 👇 -->

## What was changed

OpenTelemetry SDK was upgraded to version 1

## Why?

The OpenTelemetry auto instrumentation extension has changed its name in commit https://github.com/open-telemetry/opentelemetry-php-instrumentation/commit/3dc12db24f9e4fba5e366587d149bbd962230aa1 from `otel_instrumentation` to `opentelemetry`.

As this extension is marked as required in the SDK, it creates some incompatibility with recent versions of auto instrumentation libraries.
